### PR TITLE
nearly.t fails

### DIFF
--- a/lib/Test/Easy.pm
+++ b/lib/Test/Easy.pm
@@ -319,9 +319,9 @@ examples:
     my $coderef       = sub { 'hi' };
 
     run_where(
-        [$coderef => sub { 'bye' }],
-        [$hashref => {apple => 'banana'}],
-        [$arrayref => [qw(hi mom)]],
+        [\$coderef => sub { 'bye' }],
+        [\$hashref => {apple => 'banana'}],
+        [\$arrayref => [qw(hi mom)]],
         [\$just_a_scalar => 8843],
         sub {
             $coderef->() . join ',', %$hashref, @$arrayref, $just_a_scalar,

--- a/t/nearly.t
+++ b/t/nearly.t
@@ -46,7 +46,7 @@ sub pretty_epoch {
 		},
 	);
 
-	my $random_midnight = 895718880;        # Wed May 20 22:48:00 1998 - it's a keyrattle date
+	my $random_midnight = 895729680;        # Wed May 20 22:48:00 1998 - it's a keyrattle date
 	my $weird_date = '1998-05-20-22-48-03'; # Wed May 20 22:48:03 1998 - deliberately within 5s of above
 	ok( time_nearly($weird_date, $random_midnight, 5), "${\pretty_epoch $random_midnight} is within 5 seconds of $weird_date"	);
 }


### PR DESCRIPTION
Howdy,

I was trying to pull in Test::Easy as a test dependency for a module but kept failing on test.t (See: http://www.cpantesters.org/distro/T/Test-Easy.html?oncpan=1&distmat=1&version=1.07)

Unsure if this is just a band aid that covers a more systemic problem. 

Feel free to ignore the doc tweaks.
